### PR TITLE
Fix GitHub Release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Closes #14

## Problem
Release workflow (v0.1.0) failed at GitHub Release creation:
```
403: Resource not accessible by integration
```

## Root Cause
Missing `permissions: contents: write` in release.yml

## Impact
- crates.io publish: SUCCESS (v0.1.0 published)
- GitHub Release: FAILED (403 error)

## Solution
Added workflow-level permissions:
```yaml
permissions:
  contents: write
```

## Testing
- [x] Syntax validated
- [ ] Will be tested with next tag release

## Notes
- v0.1.0 is already on crates.io (publish worked)
- This fix enables automatic GitHub Release creation for future tags