### PR TITLE
Fix REUSE compliance for fuzz/.gitignore

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: CC0-1.0
+
 target
 corpus
 artifacts


### PR DESCRIPTION
Closes #36

## Problem

REUSE compliance check fails on main branch and blocks all PRs:
```
The following files have no copyright and licensing information:
* fuzz/.gitignore
```

## Solution

Added SPDX header to `fuzz/.gitignore`:
```
# SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
# SPDX-License-Identifier: CC0-1.0
```

## Impact

- Fixes REUSE 3.3 compliance
- Unblocks all pending PRs
- CI will pass on main branch

## Testing

- [x] SPDX header added
- [x] File still functional as .gitignore
- [ ] REUSE check will pass in CI